### PR TITLE
Add support to send AMI command with multiple headers with same name

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -20,12 +20,16 @@ Action.prototype.serialize = function() {
   var keys = Object.keys(this.data);
   var packet = '';
   for(var i = 0, key; key = keys[i]; i++) {
-    //ensure first char is uppercase (support json -> AMI casing)
-    packet += key[0].toUpperCase();
-    packet += key.substr(1);
-    packet += ': ';
-    packet += this.data[key];
-    packet += NEWLINE;
+    //got array to support multiple headers with same name
+    var values = Array.isArray(this.data[key]) ? this.data[key] : [this.data[key]];
+    for (var j = 0; j < values.length; j++) {
+      //ensure first char is uppercase (support json -> AMI casing)
+      packet += key[0].toUpperCase();
+      packet += key.substr(1);
+      packet += ': ';
+      packet += values[j];
+      packet += NEWLINE;
+    }
   }
   packet += NEWLINE;
   return packet;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -75,9 +75,11 @@ Parser.prototype.parse = function(newPacket) {
         break;
       case ':':
         //skip space after colon
-        this.setState(Parser.VALUE);
-        i++;
-        break;
+        if (this.isState(Parser.KEY)) {
+          this.setState(Parser.VALUE);
+          i++;
+          break;
+        }
       default:
         if(this.isState(Parser.FIRST_KEY) || this.isState(Parser.FIRST_NL)) {
           //make keys javascript casing

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "author": "Brian M. Carlson <brian@enginode.com> (enginode.com)",
-  "name": "ami",
+  "author": "Thiago Costa <admin@rootbsd.info>",
+  "name": "@thiagodk/ami",
   "description": "AMI (Asterisk Manager Interface) client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "repository": {
     "type": "git",
-    "url": "git://github.com/brianc/node-ami.git"
+    "url": "git://github.com/thiagodk/node-ami"
   },
   "main": "lib/",
   "scripts": {


### PR DESCRIPTION
I add a possibility to pass an array as object value in Action class to allow to set multiple headers with same name on AMI Action.

Example: Originate action can contain Variable headers